### PR TITLE
Fix event for Dexterity items

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,9 @@ Changelog
 1.2.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix `keepLink` event for Dexterity items (with referenceablebehavior enabled)
+  referenced by a smartlink. Now we can delete the DX content without errors.
+  [cekk]
 
 
 1.2.1 (2013-02-15)
@@ -87,7 +89,7 @@ __ http://plone.org/products/smart-link/issues/7
 * added the BLOB extension for image field [mircoangelini]
 * added BLOB migration view: ``blob-smartlink-migration`` [mircoangelini]
 * fixed icon handling, going back to the Plone 3 icons, disabling
-  Sunburst CSS-sprite with a new ``smart_link.css`` resource [keul] 
+  Sunburst CSS-sprite with a new ``smart_link.css`` resource [keul]
 * when linking an internal content, do not display a simple URL
   but a link using item's title [keul]
 
@@ -112,10 +114,10 @@ __ http://plone.org/products/smart-link/issues/3
 * Plone 4 compatibility [keul]
 * The explicit use of *iw.fss* has been removed. The *fss.zcml* is still there and you can still include
   it if you like, but you must do this manually [keul]
-* *ISmartLink* also extends the *IImageContent* interface [keul] 
+* *ISmartLink* also extends the *IImageContent* interface [keul]
 * A better uninstall procedure, that remove Plone UI stuff and restore original linked object status [keul]
 * Added the *favicon* field, that drive the icon's link [keul]
-* Added the *anchor* field, for manage anchor in internal links [keul] 
+* Added the *anchor* field, for manage anchor in internal links [keul]
 * Moved new and old secondary fields to the *Advanced* fieldset [keul]
 * The "unlink" event when deleting a referenced object has been removed: keeping an additional index only for
   this feature was not a soo good idea. Now the internal link will display the latest memoized link [keul]
@@ -197,7 +199,7 @@ __ http://plone.org/products/smart-link/issues/3
 
 * Fixed syntax error on relation name ("internal_page" was "interal_page") [keul]
 * Disabled the backup of basic Plone ATLink [keul]
-* Fixed some integration problem in content/link.py related to p4a (remoteUrl) [lucabel] 
+* Fixed some integration problem in content/link.py related to p4a (remoteUrl) [lucabel]
 * Fixed major bug in post_validate (validation was useless) [fdelia]
 * Internalization with i18ndude [fdelia]
 * Created italian translation [micecchi]
@@ -215,4 +217,3 @@ __ http://plone.org/products/smart-link/issues/3
 ---------------------
 
 * Initial release
-

--- a/redturtle/smartlink/README.txt
+++ b/redturtle/smartlink/README.txt
@@ -13,7 +13,7 @@ Before beginning our tour, let's configure some of the underlying stuff.
     >>> self.portal.error_log._ignored_exceptions = ()
     >>> browser.open(portal_url)
 
-Let's log in. 
+Let's log in.
 
     >>> browser.getLink('Log in').click()
     >>> browser.getControl(name='__ac_name').value = portal_owner
@@ -138,7 +138,7 @@ Additional image fields
 Smart link give to the contributor some additional fields, better described in the `product documentation`__.
 
 __ http://pypi.python.org/pypi/redturtle.smartlink
-    
+
 Here we simply test the usage of those new fields.
 
 First of all, Smart Link give a new **image** and **image caption** field as *Plone "News Item"* does.
@@ -155,9 +155,9 @@ Let's add a new image and caption to our link.
     >>> browser.getControl('Save').click()
     >>> 'Changes saved.' in browser.contents
     True
-    
+
 We need also to test if our link really behave an image now:
-    
+
     >>> contactinfo_link = portal['remote-link-sample-1']
     >>> contactinfo_link.unrestrictedTraverse('image_large')
     <Image... at /plone/remote-link-sample-1/image_large>
@@ -479,7 +479,7 @@ you preventing those possible errors.
 Using and configuring the "*Configure Smart Link*" section will make you site's contributors happy again.
 
     >>> browser.getLink('Site Setup').click()
-    >>> browser.getLink('Configure Smart Link').click()    
+    >>> browser.getLink('Configure Smart Link').click()
     >>> 'Smart Link configuration' in browser.contents
     True
 
@@ -521,7 +521,7 @@ Advanced case: back-end/fron-end transformation
 Now we see the more advanced case.
 
     >>> browser.getLink('Site Setup').click()
-    >>> browser.getLink('Configure Smart Link').click()    
+    >>> browser.getLink('Configure Smart Link').click()
     >>> 'Smart Link configuration' in browser.contents
     True
     >>> browser.getControl('Front-end main URL').value = ''
@@ -536,7 +536,7 @@ Can we also add two or more times the same URL?
     >>> browser.getControl(name='form.backendlink.0.').value = 'http://backend'
     >>> browser.getControl('Add Back-end URLs').click()
     >>> browser.getControl(name='form.backendlink.1.').value = 'http://backend'
-    >>> browser.getControl('Save').click()    
+    >>> browser.getControl('Save').click()
     >>> 'One or more entries of sequence are not unique.' in browser.contents
     True
 
@@ -579,7 +579,7 @@ Now let's see what is changed in our links all around the site, going back to ou
     >>> print browser.contents.strip()
     <!DOCTYPE html...
     ...
-    <a href="http://127.0.0.1/plone/foo-folder/my-manual" rel="external">http://127.0.0.1/plone/foo-folder/my-manual</a> 
+    <a href="http://127.0.0.1/plone/foo-folder/my-manual" rel="external">http://127.0.0.1/plone/foo-folder/my-manual</a>
     ...
     ...</html>
 
@@ -597,7 +597,7 @@ Obviously we don't need to run the migration tool when adding new links.
     >>> browser.getControl('Title').value = 'Transformed internal link: sample 6'
     >>> browser.getControl(name='internalLink').value = ffolder.UID()
     >>> browser.getControl('Save').click()
-    >>> 'This is an internal link to &quot;<a href="http://127.0.0.1/plone/foo-folder" title="">Foo folder</a>&quot;' in browser.contents    
+    >>> 'This is an internal link to &quot;<a href="http://127.0.0.1/plone/foo-folder" title="">Foo folder</a>&quot;' in browser.contents
     True
 
 As said above, all new added links will feel the configuration settings.
@@ -625,7 +625,7 @@ to internal link.
 
     >>> browser.getControl('Update existing links').click()
     >>> browser.getLink('Transformed internal link: sample 6').click()
-    >>> 'This is an internal link to &quot;<a href="/plone/foo-folder" title="">Foo folder</a>&quot;' in browser.contents    
+    >>> 'This is an internal link to &quot;<a href="/plone/foo-folder" title="">Foo folder</a>&quot;' in browser.contents
     True
 
 So all internal link are now relative link based on the Plone portal root.
@@ -649,4 +649,3 @@ above (or forget to configure at all).
 ----
 
 That's all!
-


### PR DESCRIPTION
A DX item (with referenceablebehavior enabled) referenced by a smartlink now can be deleted without errors.