### PR TITLE
Poor Man bda.contentproxy

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,6 +25,13 @@ Due to changes between Plone 3 and Plone 4 themes, we need to keep the Plone 3 a
 (not using CSS sprite. To restore the Plone 4 default way, disable the ``smart_link.css`` resource
 and remove the "*Icon (Expression)*" value from ``portal_types`` tool).
 
+When using an internal link you can choose to use title and description from the referenced content
+instead of the ones you used in the Link content itself.
+In this way the Link is more like a *proxy* of the referenced item.
+
+This feature is globally disabled by default (in the control panel), then can be enabled on every Link content
+activating the "*Use referenced content's data*" option.
+
 Handle back-end/front-end URLs
 ------------------------------
 
@@ -44,24 +51,7 @@ For this reason you must use the "*Configure Smart Link*" control panel to handl
 
 You can also use an option that says to Smart Link to store relative URLs, but this will also
 include the Plone site id in every link (and you must rewrite this from Apache if you don't
-like this). 
-
-Blob and Blob migration tool
-----------------------------
-
-SmartLink supports (starting from 1.0.0 revision) the use of blob for the image field.
-In this way we doesn't increases the size of Data.fs .
-
-The Blob support for SmartLink is activated only if `plone.app.blob`__ is installed.
-Plone 4 has Blob as storage default for the images and the files.
-On Plone 3.x you have to install it by yourself.
-
-__ http://pypi.python.org/pypi/plone.app.blob
-
-If you have already created Smark Link contents with an old version that doesn't support Blobs
-you have to launch a migration utility from the Smart Link control panel. 
-
-E.g.: http://myhost/@@blob-smartlink-migration
+like this).
 
 Migrate ATLink to Smart Link (and back)
 ---------------------------------------
@@ -100,28 +90,9 @@ Requirements
 
 Smart Link has been tested on:
 
-* Plone 3.3
-* Plone 4.2 
+* Plone 4.1
+* Plone 4.2
 * Plone 4.3
-
-Plone 3 notes
--------------
-
-There's some kwno issues for this product on Plone 3.3:
-
-* uninstall will probably not work (you can try to add to your buildout `experimental.backportGS`__)
-* uninstall will restore the Plone 4 style Link
-* you must manually activate `plone.app.imaging`__ in your Plone site
-
-__ http://pypi.python.org/pypi/experimental.backportGS
-__ http://pypi.python.org/pypi/plone.app.imaging
-
-Additional documentation
-========================
-
-You can find more documentation on the `project's home page`__
-
-__ http://plone.org/products/smart-link/documentation/
 
 Credits
 =======
@@ -129,19 +100,19 @@ Credits
 Developed with the support of:
 
 * `Camera di Commercio di Ferrara`__
-  
+
   .. image:: http://www.fe.camcom.it/cciaa-logo.png/
      :alt: CCIAA Ferrara - logo
-  
+
 * `Regione Emilia Romagna`__
 * `Azienda USL Ferrara`__
-  
+
   .. image:: http://www.ausl.fe.it/logo_ausl.gif
      :alt: Azienda USL - logo
 
 * `Rete Civica Mo-Net - Comune di Modena`__
-  
-  .. image:: http://www.comune.modena.it/grafica/logoComune/logoComunexweb.jpg 
+
+  .. image:: http://www.comune.modena.it/grafica/logoComune/logoComunexweb.jpg
      :alt: Comune di Modena - logo
 
 All of them supports the `PloneGov initiative`__.
@@ -157,9 +128,9 @@ Authors
 
 This product was developed by RedTurtle Technology team.
 
-.. image:: http://www.redturtle.net/redturtle_banner.png
+.. image:: http://www.redturtle.it/redturtle_banner.png
    :alt: RedTurtle Technology Site
-   :target: http://www.redturtle.net/
+   :target: http://www.redturtle.it/
 
 Thanks to:
 
@@ -173,4 +144,3 @@ Part of the code of Smart Link was taken from the `ComboLink`__ Plone (and Plone
 This project was giving the same internal link feature in old 2.1/2.5 Plone releases.
 
 __ http://plone.org/products/combolink/
-

--- a/docs/HISTORY.rst
+++ b/docs/HISTORY.rst
@@ -4,8 +4,7 @@ Changelog
 1.3.0 (unreleased)
 ------------------
 
-End of the official support to Plone 3: it *may* still work but has not been tested.
-
+- End of the official support to Plone 3: it *may* still work but has not been tested.
 - New feature: a way to use title and description of the referenced internal content
   (Poor Man `bda.contentproxy`__).
   This close `#6`__.

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -1,11 +1,17 @@
 Changelog
 =========
 
-1.2.3 (unreleased)
+1.3.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+End of the official support to Plone 3: it *may* still work but has not been tested.
 
+- New feature: a way to use title and description of the referenced internal content
+  (Poor Man `bda.contentproxy`__).
+  This close `#6`__.
+
+__ https://pypi.python.org/pypi/bda.contentproxy
+__ https://github.com/RedTurtle/redturtle.smartlink/issues/6
 
 1.2.2 (2016-06-15)
 ------------------

--- a/redturtle/smartlink/browser/configlet.py
+++ b/redturtle/smartlink/browser/configlet.py
@@ -17,7 +17,6 @@ except ImportError:
     MIGRATION = False
 
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
-from plone.app.form import named_template_adapter
 from plone.app.controlpanel.form import ControlPanelForm
 from plone.protect import CheckAuthenticator
 from plone.app.form.validators import null_validator
@@ -31,7 +30,7 @@ from redturtle.smartlink.interfaces.utility import ISmartLinkControlPanelForm
 
 class SmartlinkConfigForm(ControlPanelForm):
     """Smartlink Control Panel Form"""
-    
+
     implements(ISmartLinkControlPanelForm)
     template = ViewPageTemplateFile('controlpanel.pt')
 
@@ -93,4 +92,3 @@ class SmartlinkConfigForm(ControlPanelForm):
                                   default=u"${count} elements updated",
                                   mapping={'count': cnt}))
         return
-

--- a/redturtle/smartlink/content/link.py
+++ b/redturtle/smartlink/content/link.py
@@ -59,7 +59,7 @@ LinkSchema = ATLinkSchema.copy() + atapi.Schema((
     atapi.ReferenceField("internalLink",
                    default=None,
                    relationship="internal_page",
-                   multiValued=False, 
+                   multiValued=False,
                    widget=ReferenceBrowserWidget(
                         label= _(u'label_smartlink_internallink', default='Internal link'),
                         description = _(u'help_smartlink_internallink',
@@ -72,7 +72,7 @@ LinkSchema = ATLinkSchema.copy() + atapi.Schema((
     ),
 
     # ******* Advanced tab *******
-    
+
     atapi.StringField('anchor',
         required = False,
         searchable = False,
@@ -151,7 +151,7 @@ class SmartLink(ATLink):
     title = atapi.ATFieldProperty('title')
     description = atapi.ATFieldProperty('description')
     internalLink = atapi.ATReferenceFieldProperty('internalLink')
-    
+
     security = ClassSecurityInfo()
 
     security.declareProtected(permissions.View, 'size')
@@ -171,7 +171,7 @@ class SmartLink(ATLink):
             size+=f.get_size(self)
         f = self.getField('favicon')
         if f is not None:
-            size+=f.get_size(self)        
+            size+=f.get_size(self)
         return size
 
     security.declareProtected(permissions.View, 'tag')
@@ -202,7 +202,7 @@ class SmartLink(ATLink):
             image = field.getScale(self)
             if image is not None and not isinstance(image, basestring):
                 # image might be None or '' for empty images
-                return image            
+                return image
 
         return ATLink.__bobo_traverse__(self, REQUEST, name)
 
@@ -239,7 +239,7 @@ class SmartLink(ATLink):
                 anchor = '#'+anchor
             smartlink_config = queryUtility(ISmartlinkConfig, name="smartlink_config")
             if smartlink_config:
-                if smartlink_config.relativelink:            
+                if smartlink_config.relativelink:
                     object = self.getField('internalLink').get(self)
                     remote = '/'.join(object.getPhysicalPath())
                     return quote(remote + anchor, safe='?$#@/:=+;$,&%')
@@ -318,6 +318,6 @@ class SmartLink(ATLink):
                 internalPath = '/' + portal_url.getPortalObject().getId() + internalPath
             return internalPath
         return None
-        
+
 
 atapi.registerType(SmartLink, PROJECTNAME)

--- a/redturtle/smartlink/events/configure.zcml
+++ b/redturtle/smartlink/events/configure.zcml
@@ -3,11 +3,16 @@
 	       xmlns:plone="http://namespaces.plone.org/plone"
 		   xmlns:zcml="http://namespaces.zope.org/zcml"
            i18n_domain="redturtle.smartlink">
- 
+
   <subscriber for="..interfaces.ISmartLink
                    zope.lifecycleevent.interfaces.IObjectModifiedEvent"
               handler=".linker.smartLink"
             />
+
+  <subscriber for="..interfaces.ISmartLinked
+                   zope.lifecycleevent.interfaces.IObjectModifiedEvent"
+              handler=".linker.keepLink"
+              />
 
   <configure zcml:condition="not-have plone-41">
       <subscriber for="..interfaces.ISmartLink

--- a/redturtle/smartlink/interfaces/utility.py
+++ b/redturtle/smartlink/interfaces/utility.py
@@ -14,7 +14,7 @@ class ILinkNormalizerUtility(Interface):
 
     def toFrontEnd(remote):
         """Transform an URL to the proper frontend ones"""
-    
+
     def toCurrent(remote):
         """Tranform an URL to a compatible type, like the current ones"""
 
@@ -49,7 +49,7 @@ class ISmartlinkConfig(Interface):
         unique=True,
         required=False
     )
-    
+
     frontendlink = schema.List(
         title=_(u"Front-end URLs"),
         description=_(u'help_frontendlink',
@@ -59,9 +59,16 @@ class ISmartlinkConfig(Interface):
         unique=False,
         required=False
     )
-    
+
+    proxy_enabled = schema.Bool(
+        title=_(u"Globally enable proxy feature for title and description"),
+        description=_(u'help_enable_proxy_feature',
+                      default=u"Disable this if you don't want to use the \"Use referenced content's data\" feature.\n"
+                              u"Please note: changing this configuration will not update existings links automatically."),
+        default=False
+    )
+
     @invariant
     def otherFilledIfSelected(smartlink):
         if len(smartlink.frontendlink) != len(smartlink.backendlink):
             raise Invalid(_(u"Front-end link must correspond to a single back-end link"))
-    

--- a/redturtle/smartlink/locales/it/LC_MESSAGES/redturtle.smartlink.po
+++ b/redturtle/smartlink/locales/it/LC_MESSAGES/redturtle.smartlink.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: redturtle.smartlink\n"
-"POT-Creation-Date: 2013-02-15 13:27+0000\n"
+"POT-Creation-Date: 2016-12-16 17:46+0000\n"
 "PO-Revision-Date: 2010-08-27 12:31+0200\n"
 "Last-Translator: Federica D'Elia <federica.delia@redturtle.net>\n"
 "Language-Team: it\n"
@@ -54,13 +54,17 @@ msgstr "Correggi URL assoluti a link interni"
 msgid "Front-end URLs"
 msgstr "URL di front-end"
 
-#: ../interfaces/utility.py:66
+#: ../interfaces/utility.py:74
 msgid "Front-end link must correspond to a single back-end link"
 msgstr "Ad un link di front end deve corrispondere un solo link di backend"
 
 #: ../interfaces/utility.py:33
 msgid "Front-end main URL"
 msgstr "URL di front-end primario"
+
+#: ../interfaces/utility.py:64
+msgid "Globally enable proxy feature for title and description"
+msgstr "Abilita globalmente proxy per titolo e descrizione"
 
 #: ../browser/migrate.py:31
 msgid "Migrate"
@@ -137,17 +141,17 @@ msgid "description_migrate_to_smart_link"
 msgstr "Se hai degli ATLink creati prima dell'installazione di Smart Link, potresti volerli ${migrate-to-smartlink-url}."
 
 #. Default: "Please provide the external URL, or fill the \"Internal link\" field"
-#: ../content/link.py:270
+#: ../content/link.py:283
 msgid "error_externallink_internallink_required"
 msgstr "Prego fornisci un URL esterno, o compila il campo \"Link interno\""
 
 #. Default: "You must select an internal link or enter an external link. You cannot have both."
-#: ../content/link.py:276
+#: ../content/link.py:289
 msgid "error_internallink_externallink_doubled"
 msgstr "Devi selezionare un link interno o un link esterno. Non puoi fornirli entrambi."
 
 #. Default: "Please provide the internal link, or fill the \"External link\" field"
-#: ../content/link.py:272
+#: ../content/link.py:285
 msgid "error_internallink_externallink_required"
 msgstr "Prego fornisci un link interno, o compila il campo \"Link esterno\""
 
@@ -161,6 +165,13 @@ msgstr "L'URL remoto è ${real-external-link} ma punta a ${equiv-internal-link}.
 msgid "help_backendlink"
 msgstr "Inserisci qui tutti i possibili URL di back-office che vuoi trasformare. Gli URL devono essere unici"
 
+#. Default: "Disable this if you don't want to use the \"Use referenced content's data\" feature.\nPlease note: changing this configuration will not update existings links automatically."
+#: ../interfaces/utility.py:65
+msgid "help_enable_proxy_feature"
+msgstr ""
+"Disabilita se non vuoi che la funzionalità \"Usa i dati del contenuto referenziato\" sia utilizzabile.\n"
+"Nota bene: cambiando questa configurazione i Collegamenti esistenti non vengono aggiornati automaticamente."
+
 #. Default: "Put there the site main URL you want to expone to visitors. All Smart Link that starts with the current URL of the portal will be transformed to use this URL."
 #: ../interfaces/utility.py:34
 msgid "help_frontend_main_link"
@@ -172,9 +183,14 @@ msgid "help_frontendlink"
 msgstr "Inserisci qui gli URL nei quali vuoi transformare i relativi di back-office."
 
 #. Default: "Used only when the link is internal to the site. Use this field to obtain an internal link to a section of the target document"
-#: ../content/link.py:83
+#: ../content/link.py:96
 msgid "help_image_anchor"
 msgstr "Usato solo quanto il link è interno al sito. Usa questo campo per ottenere un link interno alla sezione del documento di riferimento"
+
+#. Default: "When active and an internal link is used, the Link content will use title and description from the referenced content."
+#: ../content/link.py:78
+msgid "help_internalProxy"
+msgstr "Quando attivato, e se è utilizzato un link interno, il Collegamento utilizzerà titolo e descrizione del contenuti referenziato"
 
 #. Default: "If selected, all internal links in the site will store URLs relative to the portal root, rather than absolute save the complete absolute ones. For example: no \"http://myhost/plone/foo\" but \"/plone/foo\""
 #: ../interfaces/utility.py:25
@@ -187,17 +203,17 @@ msgid "help_smartlink_externallink"
 msgstr "Inserisci l'indirizzo web di una pagina non presente su questo server"
 
 #. Default: "You can customize there the content icon. You can use this for provide the icon of the remote site"
-#: ../content/link.py:128
+#: ../content/link.py:142
 msgid "help_smartlink_favicon"
 msgstr "Puoi personalizzare qui l'icona del contenuto. Puoi usare questa funzionalità per fornire l'icona del sito remoto"
 
 #. Default: "Will be shown views that render content's images and in the link view itself"
-#: ../content/link.py:101
+#: ../content/link.py:113
 msgid "help_smartlink_image"
 msgstr "Sarà visualizzata nelle viste che permettono di mostrare le immagini contenute"
 
 #. Default: "Browse to find the internal page to which you wish to link. If this field is used, then any entry in the external link field will be ignored. You cannot have both an internal and external link."
-#: ../content/link.py:65
+#: ../content/link.py:64
 msgid "help_smartlink_internallink"
 msgstr "Sfoglia per trovare la pagina interna che si desidera linkare. Se questo campo e' usato, il campo del link esterno verra' ignorato. Non e' possibile avere sia un collegamento interno che uno esterno"
 
@@ -224,14 +240,19 @@ msgid "label_cancel_links"
 msgstr "Annulla"
 
 #. Default: "Internal anchor"
-#: ../content/link.py:82
+#: ../content/link.py:95
 msgid "label_image_anchor"
 msgstr "Ancora interna"
 
 #. Default: "Image Caption"
-#: ../content/link.py:114
+#: ../content/link.py:127
 msgid "label_image_caption"
 msgstr "Didascalia dell'immagine"
+
+#. Default: "Use referenced content's data"
+#: ../content/link.py:77
+msgid "label_internalProxy"
+msgstr "Usa i dati del contenuto referenziato"
 
 #. Default: "Save"
 #: ../browser/configlet.py:66
@@ -244,17 +265,17 @@ msgid "label_smartlink_externallink"
 msgstr "Link esterno"
 
 #. Default: "Icon"
-#: ../content/link.py:131
+#: ../content/link.py:145
 msgid "label_smartlink_favicon"
 msgstr "Icona"
 
 #. Default: "Image"
-#: ../content/link.py:103
+#: ../content/link.py:115
 msgid "label_smartlink_image"
 msgstr "Immagine"
 
 #. Default: "Internal link"
-#: ../content/link.py:64
+#: ../content/link.py:63
 msgid "label_smartlink_internallink"
 msgstr "Link interno"
 

--- a/redturtle/smartlink/locales/redturtle.smartlink.pot
+++ b/redturtle/smartlink/locales/redturtle.smartlink.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2013-02-15 13:27+0000\n"
+"POT-Creation-Date: 2016-12-16 17:46+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -56,12 +56,16 @@ msgstr ""
 msgid "Front-end URLs"
 msgstr ""
 
-#: ../interfaces/utility.py:66
+#: ../interfaces/utility.py:74
 msgid "Front-end link must correspond to a single back-end link"
 msgstr ""
 
 #: ../interfaces/utility.py:33
 msgid "Front-end main URL"
+msgstr ""
+
+#: ../interfaces/utility.py:64
+msgid "Globally enable proxy feature for title and description"
 msgstr ""
 
 #: ../browser/migrate.py:31
@@ -137,17 +141,17 @@ msgid "description_migrate_to_smart_link"
 msgstr ""
 
 #. Default: "Please provide the external URL, or fill the \"Internal link\" field"
-#: ../content/link.py:270
+#: ../content/link.py:283
 msgid "error_externallink_internallink_required"
 msgstr ""
 
 #. Default: "You must select an internal link or enter an external link. You cannot have both."
-#: ../content/link.py:276
+#: ../content/link.py:289
 msgid "error_internallink_externallink_doubled"
 msgstr ""
 
 #. Default: "Please provide the internal link, or fill the \"External link\" field"
-#: ../content/link.py:272
+#: ../content/link.py:285
 msgid "error_internallink_externallink_required"
 msgstr ""
 
@@ -161,6 +165,11 @@ msgstr ""
 msgid "help_backendlink"
 msgstr ""
 
+#. Default: "Disable this if you don't want to use the \"Use referenced content's data\" feature.\nPlease note: changing this configuration will not update existings links automatically."
+#: ../interfaces/utility.py:65
+msgid "help_enable_proxy_feature"
+msgstr ""
+
 #. Default: "Put there the site main URL you want to expone to visitors. All Smart Link that starts with the current URL of the portal will be transformed to use this URL."
 #: ../interfaces/utility.py:34
 msgid "help_frontend_main_link"
@@ -172,8 +181,13 @@ msgid "help_frontendlink"
 msgstr ""
 
 #. Default: "Used only when the link is internal to the site. Use this field to obtain an internal link to a section of the target document"
-#: ../content/link.py:83
+#: ../content/link.py:96
 msgid "help_image_anchor"
+msgstr ""
+
+#. Default: "When active and an internal link is used, the Link content will use title and description from the referenced content."
+#: ../content/link.py:78
+msgid "help_internalProxy"
 msgstr ""
 
 #. Default: "If selected, all internal links in the site will store URLs relative to the portal root, rather than absolute save the complete absolute ones. For example: no \"http://myhost/plone/foo\" but \"/plone/foo\""
@@ -187,17 +201,17 @@ msgid "help_smartlink_externallink"
 msgstr ""
 
 #. Default: "You can customize there the content icon. You can use this for provide the icon of the remote site"
-#: ../content/link.py:128
+#: ../content/link.py:142
 msgid "help_smartlink_favicon"
 msgstr ""
 
 #. Default: "Will be shown views that render content's images and in the link view itself"
-#: ../content/link.py:101
+#: ../content/link.py:113
 msgid "help_smartlink_image"
 msgstr ""
 
 #. Default: "Browse to find the internal page to which you wish to link. If this field is used, then any entry in the external link field will be ignored. You cannot have both an internal and external link."
-#: ../content/link.py:65
+#: ../content/link.py:64
 msgid "help_smartlink_internallink"
 msgstr ""
 
@@ -222,13 +236,18 @@ msgid "label_cancel_links"
 msgstr ""
 
 #. Default: "Internal anchor"
-#: ../content/link.py:82
+#: ../content/link.py:95
 msgid "label_image_anchor"
 msgstr ""
 
 #. Default: "Image Caption"
-#: ../content/link.py:114
+#: ../content/link.py:127
 msgid "label_image_caption"
+msgstr ""
+
+#. Default: "Use referenced content's data"
+#: ../content/link.py:77
+msgid "label_internalProxy"
 msgstr ""
 
 #. Default: "Save"
@@ -242,17 +261,17 @@ msgid "label_smartlink_externallink"
 msgstr ""
 
 #. Default: "Icon"
-#: ../content/link.py:131
+#: ../content/link.py:145
 msgid "label_smartlink_favicon"
 msgstr ""
 
 #. Default: "Image"
-#: ../content/link.py:103
+#: ../content/link.py:115
 msgid "label_smartlink_image"
 msgstr ""
 
 #. Default: "Internal link"
-#: ../content/link.py:64
+#: ../content/link.py:63
 msgid "label_smartlink_internallink"
 msgstr ""
 

--- a/redturtle/smartlink/tests/base.py
+++ b/redturtle/smartlink/tests/base.py
@@ -16,6 +16,8 @@ from Products.PloneTestCase import PloneTestCase as ptc
 from Products.PloneTestCase.layer import onsetup
 from Products.PloneTestCase.setup import default_password
 
+CSRF_DISABLED_BACKUP = None
+
 # When ZopeTestCase configures Zope, it will *not* auto-load products
 # in Products/. Instead, we have to use a statement such as:
 #   ztc.installProduct('SimpleAttachment')
@@ -76,11 +78,28 @@ class FunctionalTestCase(ptc.FunctionalTestCase):
     code in here.
     """
 
+    def setUp(self):
+        ptc.FunctionalTestCase.setUp(self)
+        try:
+            from plone.protect import auto
+            CSRF_DISABLED_BACKUP = auto.CSRF_DISABLED
+            auto.CSRF_DISABLED = True
+        except ImportError:
+            pass
+
     def afterSetUp(self):
         self.portal.portal_membership.addMember('contributor',
                                                 default_password,
                                                 ('Member', 'Contributor'), [])
         self.setRoles(('Manager', ))
+
+    def tearDown(self):
+        ptc.FunctionalTestCase.tearDown(self)
+        try:
+            from plone.protect import auto
+            auto.CSRF_DISABLED = CSRF_DISABLED_BACKUP
+        except ImportError:
+            pass
 
     def getImage(self):
         image = '/'.join(os.path.realpath( __file__ ).split(os.path.sep )[:-2])

--- a/redturtle/smartlink/tests/base.py
+++ b/redturtle/smartlink/tests/base.py
@@ -82,6 +82,7 @@ class FunctionalTestCase(ptc.FunctionalTestCase):
         ptc.FunctionalTestCase.setUp(self)
         try:
             from plone.protect import auto
+            global CSRF_DISABLED_BACKUP
             CSRF_DISABLED_BACKUP = auto.CSRF_DISABLED
             auto.CSRF_DISABLED = True
         except ImportError:

--- a/redturtle/smartlink/tests/test_proxy.py
+++ b/redturtle/smartlink/tests/test_proxy.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+
+import unittest
+from redturtle.smartlink.interfaces.utility import ISmartlinkConfig
+from redturtle.smartlink.tests.base import TestCase
+from zope.component import getUtility
+from zope.event import notify
+from zope.lifecycleevent import ObjectModifiedEvent
+
+
+class ProxyTestSetup(TestCase):
+    """ Testing the proxy feature """
+
+    def afterSetUp(self):
+        self.loginAsPortalOwner()
+        self.setRoles(('Manager', ))
+        self.smartlink_config = getUtility(
+            ISmartlinkConfig, name="smartlink_config"
+        )
+        self.smartlink_config.proxy_enabled = True
+        self.folder.invokeFactory(
+            type_name='Link', id='the-link',
+            title='Link to something', description='This is a link'
+        )
+        self.link = self.folder['the-link']
+        self.folder.invokeFactory(
+            type_name='Document', id='internal-document',
+            title='Internal doc', description='This is a document'
+        )
+        self.doc = self.folder['internal-document']
+        self.link.setInternalProxy(True)
+        self.link.setInternalLink(self.doc)
+        self.link.reindexObject()
+        notify(ObjectModifiedEvent(self.link))
+
+    def test_widget_feature_disabled(self):
+        self.smartlink_config.proxy_enabled = False
+        html = self.link.base_edit()
+        self.assertFalse('"internalProxy"' in html)
+
+    def test_widget_feature_enabled(self):
+        html = self.link.base_edit()
+        self.assertTrue('"internalProxy"' in html)
+
+    def test_linked_ct_attributes(self):
+        self.assertEqual(self.link.Title(), self.doc.Title())
+        self.assertEqual(self.link.Description(), self.doc.Description())
+        # attributes access is not proxied
+        self.assertEqual(self.link.title, 'Link to something')
+
+    def test_catalog_metadata(self):
+        result = self.portal.portal_catalog(portal_type='Link')[0]
+        self.assertEqual(result.Title, self.doc.Title())
+        self.assertEqual(result.Description, self.doc.Description())
+
+    def test_catalog_index(self):
+        results = self.portal.portal_catalog(Title='Internal doc')
+        self.assertEqual(len(results), 2)
+        results = self.portal.portal_catalog(Description='a document')
+        self.assertEqual(len(results), 2)
+
+    def test_catalog_updated_on_change(self):
+        self.doc.edit(title="This is a page", description="Foo bar baz")
+        self.doc.reindexObject()
+        notify(ObjectModifiedEvent(self.doc))
+        results = self.portal.portal_catalog(
+            Title='a page', portal_type='Link'
+        )
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].Title, "This is a page")
+        results = self.portal.portal_catalog(
+            Description='Foo bar baz', portal_type='Link'
+        )
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].Description, "Foo bar baz")
+
+
+def test_suite():
+    suite = unittest.TestSuite()
+    suite.addTest(unittest.makeSuite(ProxyTestSetup))
+    return suite

--- a/redturtle/smartlink/tests/test_utility.py
+++ b/redturtle/smartlink/tests/test_utility.py
@@ -1,32 +1,43 @@
 # -*- coding: utf-8 -*-
 
 import unittest
+from redturtle.smartlink.interfaces.utility import ILinkNormalizerUtility
+from redturtle.smartlink.interfaces.utility import ISmartlinkConfig
+from redturtle.smartlink.tests.base import TestCase
 from zope.component import getUtility
 
-from redturtle.smartlink.tests.base import TestCase
-from redturtle.smartlink.interfaces.utility import ISmartlinkConfig, ILinkNormalizerUtility
 
-class BasicTestSetup(TestCase):
+class UtilityTestSetup(TestCase):
 
     def afterSetUp(self):
         self.loginAsPortalOwner()
         self.setRoles(('Manager', ))
         self.utility = getUtility(ILinkNormalizerUtility)
-        self.smartlink_config = getUtility(ISmartlinkConfig, name="smartlink_config")
-    
+        self.smartlink_config = getUtility(
+            ISmartlinkConfig, name="smartlink_config")
+
     def test_nonASCIILink(self):
         # See http://plone.org/products/smart-link/issues/8/view
         self.smartlink_config.backendlink.append(u'http://nohost/plone')
         self.smartlink_config.frontendlink.append(u'http://nohost')
-        self.assertEqual(self.utility.toFrontEnd('http://myhost.com/sostenibilit\xc3\xa0.pdf'),
-                         'http://myhost.com/sostenibilit\xc3\xa0.pdf')
+        self.assertEqual(
+            self.utility.toFrontEnd(
+                'http://myhost.com/sostenibilit\xc3\xa0.pdf'
+            ),
+            'http://myhost.com/sostenibilit\xc3\xa0.pdf'
+        )
         self.smartlink_config.backendlink = []
         self.smartlink_config.frontendlink = []
         self.smartlink_config.frontend_main_link = u'http://nohost/plone'
-        self.assertEqual(self.utility.toFrontEnd('http://myhost.com/sostenibilit\xc3\xa0.pdf'),
-                         'http://myhost.com/sostenibilit\xc3\xa0.pdf')
+        self.assertEqual(
+            self.utility.toFrontEnd(
+                'http://myhost.com/sostenibilit\xc3\xa0.pdf'
+            ),
+            'http://myhost.com/sostenibilit\xc3\xa0.pdf'
+        )
+
 
 def test_suite():
     suite = unittest.TestSuite()
-    suite.addTest(unittest.makeSuite(BasicTestSetup))
+    suite.addTest(unittest.makeSuite(UtilityTestSetup))
     return suite

--- a/redturtle/smartlink/utility.py
+++ b/redturtle/smartlink/utility.py
@@ -25,6 +25,7 @@ class SmartlinkConfig(SimpleItem):
     relativelink = FieldProperty(ISmartlinkConfig['relativelink'])
     frontendlink = FieldProperty(ISmartlinkConfig['frontendlink'])
     backendlink = FieldProperty(ISmartlinkConfig['backendlink'])
+    proxy_enabled = FieldProperty(ISmartlinkConfig['proxy_enabled'])
 
 
 class LinkNormalizerUtility(object):

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(name='redturtle.smartlink',
       description=("An advanced Link content type for Plone, "
                    "with image field, customizable content icon and internal link feature"),
       long_description=open("README.rst").read() + "\n" +
-                       open(os.path.join("docs", "HISTORY.txt")).read(),
+                       open(os.path.join("docs", "HISTORY.rst")).read(),
       # Get more strings from http://pypi.python.org/pypi?%3Aaction=list_classifiers
       classifiers=[
         'Development Status :: 5 - Production/Stable',

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 import os, sys
 from setuptools import setup, find_packages
 
-version = '1.2.3.dev0'
+version = '1.3.0.dev0'
 
 tests_require = ['zope.testing', 'Products.PloneTestCase']
 
@@ -26,8 +26,6 @@ setup(name='redturtle.smartlink',
       classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Framework :: Plone',
-        'Framework :: Plone :: 3.3',
-        'Framework :: Plone :: 4.0',
         'Framework :: Plone :: 4.1',
         'Framework :: Plone :: 4.2',
         'Framework :: Plone :: 4.3',


### PR DESCRIPTION
Added a new feature (disabled by default) where the internal link *can* use title and description of the referenced content.

This close #6